### PR TITLE
remove persistent rfkill block when installing new wpa_supplicant.conf

### DIFF
--- a/debian/raspberrypi-net-mods.service
+++ b/debian/raspberrypi-net-mods.service
@@ -8,6 +8,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/mv /boot/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf
 ExecStartPost=/bin/chmod 600 /etc/wpa_supplicant/wpa_supplicant.conf
+ExecStartPost=/usr/lib/raspberrypi-sys-mods/rfkill-wifi 0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This removes the persistent rfkill block configured by
wifi-country.service when installing a new wpa_supplicant.conf.  This
allows an operator configuring a headless pi to recover after booting
without setting the country code in wpa_supplicant.conf.

See the discussion in https://github.com/RPi-Distro/raspberrypi-sys-mods/pull/27  for details.