### PR TITLE
Handle case where user has unwittingly created wpa_supplicant.conf.txt

### DIFF
--- a/debian/raspberrypi-net-mods.service
+++ b/debian/raspberrypi-net-mods.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=Copy user wpa_supplicant.conf
-ConditionPathExists=/boot/wpa_supplicant.conf
+ConditionPathExistsGlob=/boot/wpa_supplicant.conf{,.txt}
 Before=dhcpcd.service
 After=systemd-rfkill.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/mv /boot/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf
+ExecStart=ExecStart=/bin/sh -c "if [ -f "/boot/wpa_supplicant.conf" ]; then /bin/mv /boot/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf; if [ -f "/boot/wpa_supplicant.conf.txt" ]; then /bin/rm /boot/wpa_supplicant.conf.txt; fi; elif [ -f "/boot/wpa_supplicant.conf.txt" ]; then /bin/mv /boot/wpa_supplicant.conf.txt /etc/wpa_supplicant/wpa_supplicant.conf; fi"
 ExecStartPost=/bin/chmod 600 /etc/wpa_supplicant/wpa_supplicant.conf
 ExecStartPost=/usr/sbin/rfkill unblock wifi
 


### PR DESCRIPTION
Inspired by the variant handling of ssh and ssh.txt, and https://github.com/raspberrypi/documentation/pull/1672, let's make the process of providing a custom wpa_supplicant.conf via the boot 
 filesystem a little easier and support the case where the user has unwittingly created the file as wpa_supplicant.conf.txt.