### PR TITLE
Fixed source interfaces.d/

### DIFF
--- a/debian/raspberrypi-net-mods.postinst
+++ b/debian/raspberrypi-net-mods.postinst
@@ -5,11 +5,13 @@ set -e
 ORIGSUM=c733430790aeafd2fb03d51a74381e7b
 ORIGSUM2=6b0af7757bfe7fb835cc37847edd15d2
 ORIGSUM3=4b09c86aaeef72f7afda6caeccf40882
+ORIGSUM4=5ec6753eca18efe8c8a300dbe2095080
 OLDSUM101=7759b1f54568d1b7e1996401558ded15
 OLDSUM110=ea46d8ac1d6e44d5d924855e0902f3e4
 OLDSUM120=5411833b89f7261eaf90cc3153a208b6
 OLDSUM125=0200b0a5dd541dc428a0d9c7116ad08d
-CURSUM=c82e7473bb1490cf4702aaf7b669bb33
+OLDSUM133=c82e7473bb1490cf4702aaf7b669bb33
+CURSUM=6f9f4b84383896d760d73797ea9e4744
 
 checksum () {
 	echo "$1  /etc/network/interfaces" | md5sum -c --status 2> /dev/null
@@ -17,13 +19,15 @@ checksum () {
 
 case "$1" in
     configure)
-	if checksum $OLDSUM125 || \
+	if checksum $OLDSUM133 || \
+	   checksum $OLDSUM125 || \
 	   checksum $OLDSUM120 || \
 	   checksum $OLDSUM110 || \
 	   checksum $OLDSUM101 || \
 	   checksum $ORIGSUM || \
 	   checksum $ORIGSUM2 || \
 	   checksum $ORIGSUM3 || \
+	   checksum $ORIGSUM4 || \
 
 	   [ ! -e /etc/network/interfaces ]; then
 			echo "Updating /etc/network/interfaces. Original backed up as interfaces.dpkg-old."
@@ -42,7 +46,7 @@ case "$1" in
 # For static IP, consult /etc/dhcpcd.conf and 'man dhcpcd.conf'
 
 # Include files from /etc/network/interfaces.d:
-source-directory /etc/network/interfaces.d
+source /etc/network/interfaces.d/*
 EOF
     if dpkg --compare-versions "${2}" lt "1.2.7"; then
       if [ -f /etc/systemd/system/dhcpcd.service.d/wait.conf ]; then


### PR DESCRIPTION
Source every file in /etc/network/interfaces from /etc/network/interfaces.d
(ie. even if they have an extension like *.cfg)

Merged from Debian ifupdown >=0.8.36
See: https://salsa.debian.org/debian/ifupdown/-/merge_requests/4

Checksums in postinstall scripts are updated as follows:
* CURSUM: checksum of new `interfaces` file
* OLDSUM133: checksum of previous `interfaces` file (ie. from version 1.3.3)
* ORIGSUM4: checksum of `interfaces` file shipped with Debian ifupdown 0.8.36