### PR TITLE
debian/control: remove unneeded dependency on network-manager.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,5 @@ Standards-Version: 4.3.0
 
 Package: raspberrypi-net-mods
 Architecture: all
-Depends: ${misc:Depends}, network-manager,
- raspi-config (>= 20220804)
+Depends: ${misc:Depends}, raspi-config (>= 20220804)
 Description: Network configuration for the Raspberry Pi UI


### PR DESCRIPTION
It was added in 8021bb1386a7bf2e8f8c5c95e97a51bce9f40b72 as an alternative to dhcpcd5, but when dhcpcd5 was removed in 1a37b2b288cffefc3a7dd3bd512f4a070c59110c network-manager was left there.

Fixes removing network-manager without uninstalling raspberrypi-net-mods too:

```console
menakite@raspy:~ $ sudo apt remove --purge network-manager
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  dns-root-data dnsmasq-base libbluetooth3 libcurl3-gnutls libmm-glib0 libndp0 libnetfilter-conntrack3 libnfnetlink0 libnm0 libteamdctl0
Use 'sudo apt autoremove' to remove them.
The following packages will be REMOVED:
  network-manager* raspberrypi-net-mods*
0 upgraded, 0 newly installed, 2 to remove and 0 not upgraded.
After this operation, 16.1 MB disk space will be freed.
Do you want to continue? [Y/n] n
Abort.
menakite@raspy:~ $
```